### PR TITLE
Add optional watermark task parameters

### DIFF
--- a/src/watermarker/api.py
+++ b/src/watermarker/api.py
@@ -190,6 +190,11 @@ async def watermark_batch(
     text: str,
     position: str = "top-left",
     font_file: str | None = None,
+    font_size: int | None = None,
+    padding: int | None = None,
+    font_color: str | None = None,
+    border_color: str | None = None,
+    border_thickness: int | None = None,
     api_key: str = Depends(get_api_key),
 ):
     valid_positions = ["top-left", "top-right", "bottom-left", "bottom-right", "center"]
@@ -216,6 +221,11 @@ async def watermark_batch(
         watermark_text=text,
         position=position,
         config=cfg,
+        font_size=font_size,
+        padding=padding,
+        font_color=font_color,
+        border_color=border_color,
+        border_thickness=border_thickness,
     )
 
     return {

--- a/src/watermarker/tasks/watermark.py
+++ b/src/watermarker/tasks/watermark.py
@@ -113,6 +113,11 @@ async def process_watermark_task(
     position: str,
     config: Dict[str, Any],
     retry_count: int = 0,
+    font_size: int | None = None,
+    padding: int | None = None,
+    font_color: str | None = None,
+    border_color: str | None = None,
+    border_thickness: int | None = None,
 ) -> None:
     task = TaskManager.get_task(task_id)
     if not task:
@@ -133,6 +138,11 @@ async def process_watermark_task(
                 watermark_text,
                 position=position,
                 config=config,
+                font_size=font_size,
+                padding=padding,
+                font_color=font_color,
+                border_color=border_color,
+                border_thickness=border_thickness,
             ),
         )
         TaskManager.update_task_status(
@@ -157,7 +167,17 @@ async def process_watermark_task(
             )
             await asyncio.sleep(delay)
             await process_watermark_task(
-                task_id, input_path, watermark_text, position, config, retry_count + 1
+                task_id,
+                input_path,
+                watermark_text,
+                position,
+                config,
+                retry_count + 1,
+                font_size=font_size,
+                padding=padding,
+                font_color=font_color,
+                border_color=border_color,
+                border_thickness=border_thickness,
             )
         else:
             TaskManager.update_task_status(
@@ -175,6 +195,11 @@ async def process_batch_task(
     watermark_text: str,
     position: str,
     config: Dict[str, Any],
+    font_size: int | None = None,
+    padding: int | None = None,
+    font_color: str | None = None,
+    border_color: str | None = None,
+    border_thickness: int | None = None,
 ) -> None:
     task = TaskManager.get_task(task_id)
     if not task:
@@ -200,6 +225,11 @@ async def process_batch_task(
                         watermark_text,
                         position=position,
                         config=config,
+                        font_size=font_size,
+                        padding=padding,
+                        font_color=font_color,
+                        border_color=border_color,
+                        border_thickness=border_thickness,
                     ),
                 )
                 processed.append((file_path, output))


### PR DESCRIPTION
## Summary
- allow background tasks to customize font size, padding, colors
- propagate these options through API endpoints
- update batch processing to support same parameters
- extend tests with extra parameter case

## Testing
- `pip install -q -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887769e166c8326a0d72b2c1d604789